### PR TITLE
Can this library be used with native ESP8266 Ethernet drivers such as lwIP_enc28j60?

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ lib/
 test/
 examples/WifiConfig.h
 examples/advancedExample/WifiConfig.h
+WifiConfig.h

--- a/examples/advancedExample/advancedExample.ino
+++ b/examples/advancedExample/advancedExample.ino
@@ -125,7 +125,7 @@ void loop() {
         processSyncEvent (ntpEvent);
     }
 
-    if ((millis () - last) > SHOW_TIME_PERIOD) {
+    if ((millis () - last) >= SHOW_TIME_PERIOD) {
         last = millis ();
         Serial.print (i); Serial.print (" ");
         Serial.print (NTP.getTimeDateStringUs ()); Serial.print (" ");

--- a/platformio.ini
+++ b/platformio.ini
@@ -13,7 +13,7 @@ src_dir = ./examples/
 lib_dir = .
 
 [debug]
-debug = ;-DDEBUG_NTPCLIENT
+debug = ;-DDEBUG_NTPCLIENT=3
 
 [env]
 upload_speed = 921600

--- a/src/ESPNtpClient.cpp
+++ b/src/ESPNtpClient.cpp
@@ -112,7 +112,7 @@ int32_t flipInt32 (int32_t number) {
     }
 
     //DEBUGLOGV ("Output number %08X", *(int32_t*)output);
-    int32_t *result = (int32_t*)output;
+    int32_t* result = (int32_t*)output;
     return *result;
 }
 
@@ -180,7 +180,7 @@ bool NTPClient::begin (const char* ntpServerName, bool manageWifi) {
     
 
     udp = udp_new ();
-    if (!udp){
+    if (!udp) {
         DEBUGLOGE ("Failed to create NTP socket");
         return false;
     }
@@ -302,8 +302,8 @@ void NTPClient::processPacket (struct pbuf* packet) {
     }
 
     responseTimer.detach ();
-    
-    if (!decodeNtpMessage ((uint8_t*)packet->payload, packet->len, &ntpPacket)){
+
+    if (!decodeNtpMessage ((uint8_t*)packet->payload, packet->len, &ntpPacket)) {
         DEBUGLOGE ("Null pointer packet");
         return;
     }
@@ -334,7 +334,7 @@ void NTPClient::processPacket (struct pbuf* packet) {
         actualInterval = longInterval;
         numSyncRetry = 0;
         DEBUGLOGI ("Offset %0.3f ms is under threshold %ld. Not updating", offsetAve / 1000.0, timeSyncThreshold);
-        if (wasPartial){
+        if (wasPartial) {
             wasPartial = false;
             if (onSyncEvent) {
                 NTPEvent_t event;
@@ -421,7 +421,7 @@ void NTPClient::processPacket (struct pbuf* packet) {
         DEBUGLOGI ("Next sync programmed for %d seconds", getLongInterval ());
         status = syncd;
         numSyncRetry = 0;
-        if (wasPartial){
+        if (wasPartial) {
             offsetApplied = true;
         }
         //Serial.printf ("Status: %d wasPartial: %d offsetApplied %d Offset %0.3f\n", status, wasPartial, offsetApplied, ((float)tvOffset.tv_sec + (float)tvOffset.tv_usec / 1000000.0) * 1000);
@@ -440,7 +440,7 @@ void NTPClient::processPacket (struct pbuf* packet) {
     }
     if (offsetApplied && onSyncEvent) {
         NTPEvent_t event;
-        if (status == partialSync){
+        if (status == partialSync) {
             event.event = partlySync;
             event.info.retrials = numSyncRetry;
             //event.info.offset = offset;
@@ -467,7 +467,7 @@ void NTPClient::s_recvPacket (void* arg, struct udp_pcb* pcb, struct pbuf* p,
     self->responsePacketValid = true;
 }
 
-void NTPClient::s_receiverTask (void* arg){
+void NTPClient::s_receiverTask (void* arg) {
     NTPClient* self = reinterpret_cast<NTPClient*>(arg);
 #ifdef ESP32
     for (;;) {
@@ -529,7 +529,7 @@ void NTPClient::s_getTimeloop (void* arg) {
             DEBUGLOGI ("Periodic loop. Millis = %d", lastGotTime);
             if (self->isConnected) {
                 if (WiFi.isConnected ()) {
-                        self->getTime ();
+                    self->getTime ();
                 } else {
                     DEBUGLOGE ("DISCONNECTED");
                     if (self->udp) {
@@ -611,7 +611,7 @@ void NTPClient::getTime () {
             event.info.serverAddress = ntpServerIPAddress;
             event.info.port = DEFAULT_NTP_PORT;
 
-            onSyncEvent (event);        
+            onSyncEvent (event);
         }
         if (dnsErrors >= 3) {
             dnsErrors = 0;
@@ -622,10 +622,10 @@ void NTPClient::getTime () {
         }
         return;
     } else {
-        DEBUGLOGI ("NTP server address resolved to %s", ntpServerIPAddress.toString ().c_str ());
+        DEBUGLOGI ("NTP server address %s resolved to %s", ntpServerName, ntpServerIPAddress.toString ().c_str ());
     }
     dnsErrors = 0;
-    if (ntpServerIPAddress == IPAddress(INADDR_NONE)) {
+    if (ntpServerIPAddress == IPAddress (INADDR_NONE)) {
         DEBUGLOGE ("IP address unset. Aborting");
         actualInterval = ntpTimeout + 500;
         DEBUGLOGI ("Set interval to = %d", actualInterval);
@@ -706,7 +706,7 @@ boolean NTPClient::sendNTPpacket () {
     pbuf* buffer;
     NTPUndecodedPacket_t packet;
     buffer = pbuf_alloc (PBUF_TRANSPORT, sizeof (NTPUndecodedPacket_t), PBUF_RAM);
-    if (!buffer){
+    if (!buffer) {
         DEBUGLOGE ("Cannot allocate UDP packet buffer");
         return false;
     }
@@ -847,10 +847,10 @@ bool NTPClient::setInterval (int shortInterval, int longInterval) {
         DEBUGLOGI ("Interval set to = %d", actualInterval);
         DEBUGLOGI ("Short sync interval set to %d s", shortInterval);
         DEBUGLOGI ("Long sync interval set to %d s", longInterval);
-return true;
+        return true;
     } else {
         DEBUGLOGW ("Too low interval values");
-        return false;    
+        return false;
     }
 }
 
@@ -917,10 +917,10 @@ NTPPacket_t* NTPClient::decodeNtpMessage (uint8_t* messageBuffer, size_t length,
     decPacket->peerStratum = recPacket.peerStratum;
     DEBUGLOGD ("Peer Stratum = %u", decPacket->peerStratum);
 
-    decPacket->pollingInterval = pow(2, recPacket.pollingInterval);
+    decPacket->pollingInterval = pow (2, recPacket.pollingInterval);
     DEBUGLOGD ("Polling Interval = %u", decPacket->pollingInterval);
 
-    decPacket->clockPrecission = pow(2,recPacket.clockPrecission);
+    decPacket->clockPrecission = pow (2, recPacket.clockPrecission);
     DEBUGLOGD ("Clock Precission = %0.3f us", decPacket->clockPrecission * 1000000);
 
     int16_t ts16_s = flipInt16 (recPacket.rootDelay.secondsOffset);
@@ -1006,7 +1006,7 @@ NTPPacket_t* NTPClient::decodeNtpMessage (uint8_t* messageBuffer, size_t length,
 
 bool NTPClient::checkNTPresponse (NTPPacket_t* ntpPacket, int64_t offsetUs) {
     //dumpNtpPacketInfo (ntpPacket);
-    if (ntpPacket->flags.li!=0){
+    if (ntpPacket->flags.li != 0) {
         DEBUGLOGE ("Leap indicator error: %d", ntpPacket->flags.li);
         return false;
     }
@@ -1036,10 +1036,10 @@ bool NTPClient::checkNTPresponse (NTPPacket_t* ntpPacket, int64_t offsetUs) {
 
         //Serial.printf ("Dispersion:        %0.6f s\n", ntpPacket->dispersion);
         //Serial.printf ("Offset:            %0.6f s\n", offsetUs / 1000000.0);
-        if (ntpPacket->dispersion > abs(offsetUs / 1000000.0) || ntpPacket->dispersion == 0.0) {
+        if (ntpPacket->dispersion > abs (offsetUs / 1000000.0) || ntpPacket->dispersion == 0.0) {
             DEBUGLOGE ("Dispersion error: %0.3f ms > Offset: %0.3f ms", ntpPacket->dispersion * 1000.0, (float)(offsetUs / 1000.0));
             return false;
-        }    
+        }
     }
 
     return true;

--- a/src/ESPNtpClient.cpp
+++ b/src/ESPNtpClient.cpp
@@ -159,11 +159,17 @@ bool NTPClient::begin (const char* ntpServerName, bool manageWifi) {
 
     this->manageWifi = manageWifi;
 
-    if (!setNtpServerName (ntpServerName) || !strnlen (ntpServerName, SERVER_NAME_LENGTH)) {
-        DEBUGLOGE ("Invalid NTP server name");
-        return false;
+    if (ntpServerName) {
+        if (!setNtpServerName (ntpServerName) || !strnlen (ntpServerName, SERVER_NAME_LENGTH)) {
+            DEBUGLOGE ("Invalid NTP server name");
+            return false;
+        }
+        DEBUGLOGI ("Got server name");
+    } else {
+        if (!strnlen (this->ntpServerName, SERVER_NAME_LENGTH)) {
+            setNtpServerName (DEFAULT_NTP_SERVER);
+        }
     }
-    DEBUGLOGI ("Got server name");
 
     if (udp) {
         DEBUGLOGI ("Remove UDP connection");

--- a/src/ESPNtpClient.cpp
+++ b/src/ESPNtpClient.cpp
@@ -154,9 +154,11 @@ char* dumpNTPPacket (char* data, size_t length, char* buffer, int len) {
     return buffer;
 }
 
-bool NTPClient::begin (const char* ntpServerName) {
+bool NTPClient::begin (const char* ntpServerName, bool manageWifi) {
     err_t result;
-    
+
+    this->manageWifi = manageWifi;
+
     if (!setNtpServerName (ntpServerName) || !strnlen (ntpServerName, SERVER_NAME_LENGTH)) {
         DEBUGLOGE ("Invalid NTP server name");
         return false;
@@ -607,8 +609,10 @@ void NTPClient::getTime () {
         }
         if (dnsErrors >= 3) {
             dnsErrors = 0;
-            DEBUGLOGW ("Reconnecting WiFi");
-            WiFi.reconnect ();
+            if (manageWifi) {
+                DEBUGLOGW ("Reconnecting WiFi");
+                WiFi.reconnect ();
+            }
         }
         return;
     } else {

--- a/src/ESPNtpClient.cpp
+++ b/src/ESPNtpClient.cpp
@@ -591,7 +591,7 @@ void NTPClient::s_getTimeloop (void* arg) {
 
 void NTPClient::getTime () {
     err_t result;
-    static uint dnsErrors = 0;
+    static unsigned int dnsErrors = 0;
     
     result = WiFi.hostByName (getNtpServerName (), ntpServerIPAddress);
     if (!result) {
@@ -1093,7 +1093,7 @@ bool NTPClient::adjustOffset (timeval* offset) {
     //     timersub (&currenttime, &_offset, &newtime);
     // }
 
-    if (settimeofday (&newtime, NULL)) { // hard adjustment
+    if (settimeofday (&newtime, (timezone*)NULL)) { // hard adjustment
         return false;
     }
     //Serial.printf ("millis() offset 1: %lld\n", currenttime_us / 1000 - millis ());

--- a/src/ESPNtpClient.h
+++ b/src/ESPNtpClient.h
@@ -263,6 +263,7 @@ protected:
     NTPStatus_t status = unsyncd;   ///< @brief Sync status
     char ntpServerName[SERVER_NAME_LENGTH];                         ///< @brief  of NTP server on Internet or LAN
     IPAddress ntpServerIPAddress;   ///< @brief  IP address of NTP server on Internet or LAN
+    bool manageWifi = true;   ///< @brief  Enables this library to manage wifi reconnection. True by default
 public:
 #ifdef ESP32
     //bool terminateTasks = false;
@@ -421,7 +422,7 @@ public:
       * @param ntpServerName NTP server name as String
       * @return `true` if everything went ok
       */
-    bool begin (const char* ntpServerName = DEFAULT_NTP_SERVER);
+    bool begin (const char* ntpServerName = DEFAULT_NTP_SERVER, bool manageWifi = true);
     
     /**
       * @brief Sets NTP server name

--- a/src/ESPNtpClient.h
+++ b/src/ESPNtpClient.h
@@ -16,8 +16,8 @@
 #endif
 
 #include <functional>
-using namespace std;
-using namespace placeholders;
+//using namespace std;
+//using namespace placeholders;
 
 extern "C" {
 #include "lwip/init.h"

--- a/src/ESPNtpClient.h
+++ b/src/ESPNtpClient.h
@@ -253,13 +253,13 @@ protected:
     onSyncEvent_t onSyncEvent;      ///< @brief Event handler callback
     uint16_t ntpTimeout = DEFAULT_NTP_TIMEOUT;                      ///< @brief Response timeout for NTP requests
     long minSyncAccuracyUs = DEFAULT_MIN_SYNC_ACCURACY_US;          ///< @brief DEfault minimum offset value to consider a good sync
-    uint maxNumSyncRetry = DEFAULT_MAX_RESYNC_RETRY;                ///< @brief Number of resync repetitions if minimum accuracy has not been reached
-    uint numSyncRetry;              ///< @brief Current resync repetition
-    uint maxDispersionErrors = DEFAULT_MAX_RESYNC_RETRY;            ///< @brief Number of resync repetitions if server has a dispersion value bigger than offset absolute value
-    uint numDispersionErrors;
+    unsigned int maxNumSyncRetry = DEFAULT_MAX_RESYNC_RETRY;                ///< @brief Number of resync repetitions if minimum accuracy has not been reached
+    unsigned int numSyncRetry;              ///< @brief Current resync repetition
+    unsigned int maxDispersionErrors = DEFAULT_MAX_RESYNC_RETRY;            ///< @brief Number of resync repetitions if server has a dispersion value bigger than offset absolute value
+    unsigned int numDispersionErrors;
     long timeSyncThreshold = DEFAULT_TIME_SYNC_THRESHOLD;           ///< @brief If calculated offset is below this threshold it will not be applied. 
                                                                     //            This is to avoid continious innecesary glitches in clock
-    uint numTimeouts = 0;           ///< @brief After this number of timeout responses ntp sync time is increased
+    unsigned int numTimeouts = 0;           ///< @brief After this number of timeout responses ntp sync time is increased
     NTPStatus_t status = unsyncd;   ///< @brief Sync status
     char ntpServerName[SERVER_NAME_LENGTH];                         ///< @brief  of NTP server on Internet or LAN
     IPAddress ntpServerIPAddress;   ///< @brief  IP address of NTP server on Internet or LAN
@@ -282,8 +282,8 @@ protected:
     
     int64_t offsetSum;              ///< @brief Sum of offsets for average calculation
     int64_t offsetAve;              ///< @brief Average calculated value
-    uint round = 0;                 ///< @brief Number of offset values added during last sync 
-    uint numAveRounds = DEFAULT_NUM_OFFSET_AVE_ROUNDS;          ///< @brief Number of request to be done to calculate average.
+    unsigned int round = 0;                 ///< @brief Number of offset values added during last sync 
+    unsigned int numAveRounds = DEFAULT_NUM_OFFSET_AVE_ROUNDS;          ///< @brief Number of request to be done to calculate average.
     
     pbuf* lastNtpResponsePacket;    ///< @brief Last response packet to be processed by receiver task
     bool responsePacketValid = false;                           ///< @brief Is `lastNtpResponsePacket` already processed?
@@ -759,7 +759,7 @@ public:
      * @brief Gets the number of sync attempts to calculate average offset
      * @return Number of average rounds 1.. MAX_OFFSET_AVERAGE_ROUNDS
      */
-    uint getnumAveRounds () {
+    unsigned int getnumAveRounds () {
         return numAveRounds;
     }
     

--- a/src/ESPNtpClient.h
+++ b/src/ESPNtpClient.h
@@ -422,7 +422,7 @@ public:
       * @param ntpServerName NTP server name as String
       * @return `true` if everything went ok
       */
-    bool begin (const char* ntpServerName = DEFAULT_NTP_SERVER, bool manageWifi = true);
+    bool begin (const char* ntpServerName = NULL, bool manageWifi = true);
     
     /**
       * @brief Sets NTP server name


### PR DESCRIPTION
Hi @gmag11 
Can this library be used with native ESP8266 Ethernet drivers such as lwIP_enc28j60?

For testing this purpose, I used ESP12-E with ENC28j60 ethernet module, and changed these parameters in src / ESPNtpClient.cpp :

1. WiFi.localIP()                 ---> my device IP
2. WiFi.isConnected()        ---> true
3. WiFi.reconnect()            ---> no change!

and I activated DEBUG ....

Everything looks good! But the UDP packet is not sent and returns error code -4
Do you have an opinion on this?
Thanks a lot ...